### PR TITLE
docker でFastAPIを起動する #3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
+
+COPY ./app /app

--- a/README.md
+++ b/README.md
@@ -4,30 +4,29 @@
 - [quaint-api](#quaint-api)
   - [目次](#目次)
   - [動かす](#動かす)
-    - [必要要件](#必要要件)
+    - [必要条件](#必要条件)
+    - [手順](#手順)
   - [ディレクトリ構成(ただのメモ)](#ディレクトリ構成ただのメモ)
 
 ## 動かす
+### 必要条件
+- docker https://docs.docker.com/get-docker/
+- docker-compose
+- git https://github.com/git-guides/install-git
+
+をインストールしておく
+
+### 手順
 Gitリポジトリをクローン
 ```sh
-git clone https://github.com/hibiya-itchief/quaint-api.git
+$ git clone https://github.com/hibiya-itchief/quaint-api.git
 ```
-使用するパッケージをrequirements.txt(pipreqs . で生成)でインストール
+dockerコンテナを立ち上げ
+```sh
+$ docker-compose up -d
 ```
-pip install -r requirements.txt
-```
-サーバーをスタート
-```
-uvicorn main:app --reload
-```
-http://127.0.0.1:8000/docs でAPIドキュメントが読める
 
-### 必要要件
-おそらく
-- Python 3.6+
-- pip 
-
-で動く
+http://127.0.0.1:8080/docs でAPIドキュメントが読める
 
 
 ## ディレクトリ構成(ただのメモ)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+
+
+@app.get("/items/{item_id}")
+def read_item(item_id: int, q: Optional[str] = None):
+    return {"item_id": item_id, "q": q}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8080:80"


### PR DESCRIPTION
## なぜ
- フロントエンド開発者がFastAPIによって自動生成されるSwagger UIのドキュメントを簡単に見れるようにしたい。
- Python やライブラリのバージョン統一するのが面倒くさい

## やったこと
- Dockerfile(公式ドキュメントを参照)
- docker-compose.ymlを作成
- README.mdを更新


## 
### 必要条件
- docker https://docs.docker.com/get-docker/
- docker-compose
- git https://github.com/git-guides/install-git

をインストールしておく

### 手順
Gitリポジトリをクローン
```sh
$ git clone https://github.com/hibiya-itchief/quaint-api.git
```
dockerコンテナを立ち上げ
```sh
$ docker-compose up -d
```

http://127.0.0.1:8080/docs でAPIドキュメントが読める