### PR TITLE
Hashidsに対応

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,9 @@
 from pydantic import BaseSettings
+import os
 
 class Settings(BaseSettings):
     DATABASE_URI = "mysql://quaint:password@localhost/quaint-app"
     TEST_DATABASE_URI = "mysql://quaint:password@localhost/quaint-app-test"
+    #HASHIDS_SALT = os.environ["HASHIDS_SALT"]
+    HASHIDS_SALT = "wetrfhixcrycyk"
 settings= Settings()

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,3 +1,4 @@
+from curses import has_ic
 from sqlalchemy.orm import Session
 from fastapi import Query
 from app import models,schemas,dep
@@ -5,20 +6,25 @@ from app.config import settings
 
 from hashids import Hashids
 
-hashids = Hashids(salt=settings.HASHIDS_SALT)
+hashids = Hashids(salt=settings.HASHIDS_SALT,min_length=7)
 
 def get_user(db:Session,user_id:int):
-    user = db.query(models.User).filter(models.User.id==user_id).first()
+    id=int(hashids.decode(user_id)[0])
+    user = db.query(models.User).filter(models.User.id==id).first()
     if user:
-        user.id = hashids.encode(user.id)
-    return user
+        user_result = models.User(id=hashids.encode(user.id),username=user.username,hashed_password=user.hashed_password,is_student=user.is_student,is_family=user.is_family,is_active=user.is_active,password_expired=user.password_expired)
+        return user_result
+    else:
+        return None
     
 
 def get_user_by_name(db:Session,username:str):
     user = db.query(models.User).filter(models.User.username==username).first()
     if user:
-        user.id = hashids.encode(user.id)
-    return user
+        user_result = models.User(id=hashids.encode(user.id),username=user.username,hashed_password=user.hashed_password,is_student=user.is_student,is_family=user.is_family,is_active=user.is_active,password_expired=user.password_expired)
+        return user_result
+    else:
+        return None
 
 def get_all_users(db:Session):
     raw_users = db.query(models.User).all()
@@ -28,11 +34,24 @@ def get_all_users(db:Session):
         users.append(user)
     return users
 
-def get_group(db:Session,group_id:int):
-    return db.query(models.Group).filter(models.Group.id==group_id).first()
+def get_group(db:Session,group_id:str):
+    id=int(hashids.decode(group_id)[0])
+    group = db.query(models.Group).filter(models.Group.id==id).first()
+    if group:
+        group_result = models.Group(id=hashids.encode(group.id),groupname=group.groupname,title=group.title,description=group.description)
+        return group_result
+    else:
+        return None
 
+'''
 def get_group_by_name(db:Session,groupname:str):
-    return db.query(models.Group).filter(models.Group.groupname==groupname).first()
+    group = db.query(models.Group).filter(models.Group.groupname==groupname).first()
+    if group:
+        group_result = models.Group(id=hashids.encode(group.id),groupname=group.groupname,title=group.title,description=group.description)
+        return group_result
+    else:
+        return None
+        '''
 
 def create_user(db:Session,user:schemas.UserCreate):
     hashed_password = dep.get_password_hash(user.password)
@@ -58,10 +77,11 @@ def change_password(db:Session,user:schemas.PasswordChange):
     db.commit()
     return user
 
+### 権限関係(Admin以外は要調整)
 
 def grant_admin(db:Session,user:schemas.User):
-    my_id = int(hashids.decode(user.id)[0])
-    db_admin = models.Admin(user_id=my_id)
+    id = int(hashids.decode(user.id)[0])
+    db_admin = models.Admin(user_id=id)
     db.add(db_admin)
     db.commit()
     db.refresh(db_admin)
@@ -88,7 +108,8 @@ def check_admin(db:Session,user:schemas.User):
     return True
 
 def check_owner_of(db:Session,group:schemas.Group,user:schemas.User):
-    if not db.query(models.Authority).filter(models.Authority.user_id==user.id,models.Authority.group_id==group.id,models.Authority.role==schemas.AuthorityRole.Owner).first():
+    id = int(hashids.decode(user.id)[0])
+    if not db.query(models.Authority).filter(models.Authority.user_id==id,models.Authority.group_id==group.id,models.Authority.role==schemas.AuthorityRole.Owner).first():
         return False
     return True
 

--- a/app/test/test_main.py
+++ b/app/test/test_main.py
@@ -243,6 +243,7 @@ def test_create_user_by_admin(db:Session):
     user_admin = factories.Admin_UserCreateByAdmin()
     crud.create_user_by_admin(db,user_admin)
     admin = crud.get_user_by_name(db,user_admin.username)
+    print(admin)
     crud.grant_admin(db,admin)
     response = client.post(
         "/token",

--- a/app/test/test_main.py
+++ b/app/test/test_main.py
@@ -270,3 +270,11 @@ def test_create_user_by_admin(db:Session):
     )
     print(response.json())
     assert response.status_code == 200
+
+
+def test_get_user_by_name(db:Session):
+    user_in = factories.hogehoge_UserCreateByAdmin()
+    crud.create_user_by_admin(db,user_in)
+    user = crud.get_user_by_name(db,"hogehoge")
+    print(user)
+    assert user


### PR DESCRIPTION
# なぜ
現状では各idがSQLのauto_incrementで振られたわかりやすい連番なので、いじってほかのところにアクセスしようとする人がいそう。
# やったこと
crudでhashidsとidの変換を行った。
dbではauto_incrementで生成されるidをそのまま使える
crudの外ではidはhashidsされたstrとして扱う

各スキーマのid:int となっているのはid:strとした

sqlalchemyのqueryで取得したrowproxy型はそのまま値を変更すると次のdb.commit()で更新されちゃうから、一回インスタンスを作ってそっちを変更する(伝わるかな)

close #17 