### PR TITLE
GitHub actionsによるpytestでcoverage可視化

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,7 @@
 
 name: pytest
 
+permissions: write-all
 
 # Controls when the workflow will run
 on:
@@ -30,4 +31,25 @@ jobs:
       - name: Test with pytest on Docker
         run: |
           docker-compose up -d
-          docker-compose exec -T app bash /app/wait-for-it.sh db:3306 -t 60 -- pytest
+          docker-compose exec -T app bash /app/wait-for-it.sh db:3306 -t 60 -- pytest --cov --junitxml=/app/app/test/pytest.xml --cov-report=term-missing:skip-covered > ./pytest-coverage.txt
+
+      - name: Create Coverage Comment
+        id: coverageComment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+            pytest-coverage-path: ./pytest-coverage.txt
+            junitxml-path: ./app/test/pytest.xml
+
+      - name: Create Coverage Badge
+        uses: schneegans/dynamic-badges-action@v1.3.0
+        with:
+            auth: ${{ secrets.BADGE_GIST }} # 名前は適宜変更:手順5で決めたトークン名
+            gistID: 81370c9284b6c64224021c2c6520c2e3 #先ほど控えたGist ID
+            # 以降はコピペ可
+            # cerverageCommentはPytest Coverage CommentのID
+            # 書き換えた場合は変更が必要
+            filename: pytest-coverage-comment.json
+            label: Coverage
+            message: ${{ steps.coverageComment.outputs.coverage }}
+            color: ${{ steps.coverageComment.outputs.color }}
+            namedLogo: python

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # quaint-api
-[![pytest](https://github.com/hibiya-itchief/quaint-api/actions/workflows/pytest.yml/badge.svg)](https://github.com/hibiya-itchief/quaint-api/actions/workflows/pytest.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Ekke-kuru2/81370c9284b6c64224021c2c6520c2e3/raw/pytest-coverage-comment.json)](https://github.com/hibiya-itchief/quaint-api/actions)
 ---
 星陵祭オンライン整理券システム「QUAINT」のバックエンドAPI
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ yarg==0.1.9
 mysqlclient
 python-dotenv
 ulid-py
+pytest-cov


### PR DESCRIPTION
READMEに表示されるバッジをpassingがfailかではなく、カバレッジの表示にする
Pull Requestをつくるとpytestの概要が表示される
close #38 