### PR TITLE
104 google analytics apiをたたくエンドポイント

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 db/data
 .pytest_cache
 data/*
+app/ga-credential.json

--- a/app/.env.example
+++ b/app/.env.example
@@ -10,6 +10,12 @@ MYSQL_USER=
 MYSQL_PASSWORD=
 MYSQL_DATABASE=
 
+### Redisへの接続情報
+REDIS_HOST=
+
+### Google Analytics Property ID
+GA_PROPERTY_ID =
+
 ### JWTに署名するために必要な秘密鍵
 # @ekkekuru2に問い合わせて下さい
 # **本番は必ず鍵を変更すること**

--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,12 @@ class Settings(BaseSettings):
     ## Cloudflare deploy hook url
     cloudflare_deploy_hook_url:str=os.getenv("CLOUDFLARE_DEPLOY_HOOK_URL","")
 
+    ## Redis
+    redis_host:str=os.getenv("REDIS_HOST","")
+
+    ## Google Analytics Property ID
+    ga_property_id:str=os.getenv("GA_PROPERTY_ID","")
+
     class Config:
         env_file = 'app/.env'
         secrets_dir='/run/secrets'

--- a/app/ga.py
+++ b/app/ga.py
@@ -1,0 +1,45 @@
+import os
+
+import redis
+from google.analytics.data_v1beta import BetaAnalyticsDataClient
+from google.analytics.data_v1beta.types import (DateRange, Dimension, Filter,
+                                                FilterExpression,
+                                                FilterExpressionList, Metric,
+                                                RunReportRequest)
+
+from app.config import settings
+
+# credential.json環境変数に保存 app.gaがapp.mainによって読み込まれる時に実行
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'app/ga-credential.json'
+
+def ga_api_request_screenpageview(start_date:str,page_path:str,end_date:str):
+    client = BetaAnalyticsDataClient()
+    request = RunReportRequest(
+        property=f"properties/{settings.ga_property_id}",
+        metrics=[Metric(name="screenPageViews")],
+        date_ranges=[DateRange(start_date=start_date, end_date=end_date)],
+        dimension_filter=FilterExpression(
+                filter=Filter(
+                    field_name="pagePath",
+                    string_filter=Filter.StringFilter(value=page_path),
+                )
+            )
+    )
+    response = client.run_report(request)
+    screenpageview:int = response.rows[0].metric_values[0].value
+    return screenpageview
+def ga_screenpageview(start_date:str,page_path:str,end_date:str):
+    try:
+        redis_conn = redis.Redis(host=settings.redis_host, port=6379, db=0,decode_responses=True)
+        screenpageview_cache=redis_conn.get("ga-screenpageview-"+start_date+end_date+page_path)
+        if screenpageview_cache:
+            return int(screenpageview_cache)
+        else:
+            screenpageview = ga_api_request_screenpageview(start_date,page_path,end_date)
+            redis_conn.set("ga-screenpageview-"+start_date+end_date+page_path,screenpageview,ex=60) # expire 1min
+            return screenpageview
+    except: # Redisへの接続に失敗
+        screenpageview = ga_api_request_screenpageview(start_date,page_path,end_date)
+        return screenpageview
+
+

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from starlette.status import (HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN,
 
 from app import auth, crud, db, models, schemas, storage
 from app.config import settings
+from app.ga import ga_screenpageview
 from app.msgraph import MsGraph
 
 #models.Base.metadata.create_all(bind=engine)
@@ -51,6 +52,10 @@ tags_metadata = [
     {
         "name": "admin",
         "description": "管理者用API"
+    },
+    {
+        "name": "ga",
+        "description": "Google Analytics"
     }
 
 ]
@@ -496,6 +501,15 @@ def delete_tag(tag_id:str,permission:schemas.JWTUser=Depends(auth.admin),db:Sess
         raise HTTPException(404,"指定されたTagが見つかりません")
     return "Successfully Deleted"
     
+
+@app.get(
+    "/ga/screenpageview",
+    response_model=schemas.GAScreenPageViewResponse,
+    summary="Google Analyticsのビュー数を取得",
+    tags=["ga"],
+    description="### 必要な権限\nなし\n### ログインが必要か\nいいえ\n### 説明\nGoogle Analyticsのビュー数を取得します \n start_dateとend_dateの形式：YYYY-MM-DD, NdaysAgo, yesterday, or today \n page_path は/から始まる相対パス(/はurlで送れないのでURL Encodeする) \n Redisで1分毎にキャッシュしています")
+def get_ga_screenpageview(start_date:str,end_date:str,page_path:str):
+    return {"start_date":start_date,"end_date":end_date,"page_path":page_path,"view":ga_screenpageview(start_date,page_path,end_date)}
 
 
 #@app.put("/admin/user")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -121,6 +121,12 @@ class GroupOwner(BaseModel):
     class Config:
         orm_mode=True
 
+class GAScreenPageViewResponse(BaseModel):
+    start_date:str
+    end_date:str
+    page_path:str
+    view:int
+
 
 Event.update_forward_refs()
 Group.update_forward_refs()

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -11,3 +11,8 @@ services:
     ports:
       - "8000:8000"
     command: /bin/bash /workspace/docker_startup.sh
+
+  redis:
+    image: "redis:latest"
+    volumes:
+      - "./redis.conf:/etc/redis.conf"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -23,6 +23,11 @@ services:
       - "8010:8000"
     command: /bin/bash /workspace/docker_startup.sh
 
+  redis:
+    image: "redis:latest"
+    volumes:
+      - "./redis.conf:/etc/redis.conf"
+
   phpmyadmin:
     image: phpmyadmin
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,12 @@ services:
     ports:
       - "8000:8000"
     command: /bin/bash /workspace/docker_startup.sh
+
+  redis:
+    image: "redis:latest"
+    volumes:
+      - "./redis.conf:/etc/redis.conf"
+
   phpmyadmin:
     image: phpmyadmin
     restart: always

--- a/redis.conf
+++ b/redis.conf
@@ -1,0 +1,2 @@
+maxmemory 100MB
+maxmemory-policy allkeys-lru

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,6 @@ bcrypt
 PyJWT[crypt]
 cryptography
 redis[hiredis]
+google-api-python-client
+google-analytics-data
+oauth2client

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ pillow
 bcrypt
 PyJWT[crypt]
 cryptography
+redis[hiredis]


### PR DESCRIPTION
Google AnalyticsのAPIが結構遅いのと、レート制限があるので、redisでキャッシュするようにした
dockerだと書くだけで使えて便利
redisへの接続は自動的にプールされるらしい