### PR TITLE
check_owner_of()のuser_oidのバグを修正

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -41,7 +41,7 @@ def get_ownership_of_user(db:Session,user_oid:str)->List[str]:
     return result
 def check_owner_of(db:Session,user:schemas.JWTUser,group_id:str):
     try:
-        if group_id in get_ownership_of_user(db,user.sub):
+        if group_id in get_ownership_of_user(db,auth.user_object_id(user)):
             return True
         else:
             return False


### PR DESCRIPTION
user.subで取得してた
userのObjectはauth.user_object_id(user:JWTUser)を通して取得する
よりによって一番いけないところに残ってた