### PR TITLE
Redisキャッシュの採用

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -181,10 +181,6 @@ def get_group(group_id:str,db:Session=Depends(db.get_db)):
         raise HTTPException(404,"指定されたGroupが見つかりません")
     return group_result
 
-@app.get("/groups/{group_id}/private")
-def get_group_private():
-    pass
-
 @app.put(
     "/groups/{group_id}",
     response_model=schemas.Group,

--- a/app/redis_possible.py
+++ b/app/redis_possible.py
@@ -1,0 +1,26 @@
+from typing import Union
+
+import redis
+
+from app.config import settings
+
+
+def redis_get_if_possible(key:str)->Union[str,None]:
+    try:
+        redis_conn = redis.Redis(host=settings.redis_host, port=6379, db=0,decode_responses=True)
+        cache_result=redis_conn.get(key)
+        if cache_result:
+            return cache_result
+    except:
+        pass
+    return None
+def redis_set_if_possible(key:str,value:str,ex:int):
+    try:
+        redis_conn = redis.Redis(host=settings.redis_host, port=6379, db=0,decode_responses=True)
+        result=redis_conn.set(key,value,ex)
+        if result==0:
+            return 0
+    except:
+        pass
+    return 1
+

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -133,3 +133,16 @@ Group.update_forward_refs()
 Tag.update_forward_refs()
 Ticket.update_forward_refs()
 
+def EventDBOutput_fromEvent(e:Event):
+    return EventDBOutput(
+        eventname=e.eventname,
+        lotterry=e.lottery,
+        target=e.target,
+        ticket_stock=e.ticket_stock,
+        starts_at=e.starts_at.isoformat(),
+        ends_at=e.ends_at.isoformat(),
+        sell_starts=e.sell_starts.isoformat(),
+        sell_ends=e.sell_ends.isoformat(),
+        id=e.id,
+        group_id=e.group_id
+    )


### PR DESCRIPTION
RedisとはAPIサーバーのメモリ上に展開されるデータストア
DBサーバーと違い、ディスクではなくメモリに保存するので、速い

## 残席状況をRedisキャッシュ
[これ](https://github.com/hibiya-itchief/quaint-app/issues/251)とかやるんだとしたら、残席状況のエンドポイントはめちゃくちゃ呼ばれそうだから

### TTL(キャッシュが残る時間)=15秒
- /groups/{group_id}/events/{event_id}/tickets [GET]


## 認証が必要のないエンドポイントは全てRedisキャッシュするように
悪意のある人がそのエンドポイントにF5連打とかしてDB負荷かかったら嫌だから

### TTL=120秒
- /groups [GET]
- /groups/{group_id} [GET]
- /groups/{group_id}/events [GET]
- /groups/{group_id}/events/{event_id} [GET]

### TTL=60秒
- /ga/get_ga_screenpageview [GET]


## 留意事項
メモリを食いすぎないように容量に気を付ける必要あり
↓参考までに5月の負荷テスト
CPU4コア,メモリ16GBのサーバー×4台にスケールアウト
![image](https://github.com/hibiya-itchief/quaint-api/assets/71656810/e459792d-3d90-4f39-bcb0-82c07962aaa3)
